### PR TITLE
Feature/customize row

### DIFF
--- a/ELM_CHANGELOG.md
+++ b/ELM_CHANGELOG.md
@@ -1,5 +1,9 @@
 # Elm Changelog
 
+## [9.0.0]
+
+- Added `rowId` to `GridConfig` allowing to configure a custom rowId depending on a data attribute
+
 ## [8.0.0]
 
 - Added `suppressRowDeselection` and `rowMultiSelectWithClick` attributes to the `GridConfig`

--- a/NPM_CHANGELOG.md
+++ b/NPM_CHANGELOG.md
@@ -1,5 +1,9 @@
 # NPM Changelog
 
+## [3.2.0]
+
+- Added callback value to customize the row ID
+
 ## [3.1.1]
 
 - Using null-safe access operator for `getRowId`

--- a/ag-grid-webcomponent/index.js
+++ b/ag-grid-webcomponent/index.js
@@ -182,7 +182,7 @@ class AgGrid extends HTMLElement {
   _initializeGrid() {
     const self = this;
 
-    this.gridOptions = {
+    let gridOptions = {
       components: {
         ...cellRenderer,
         ...cellEditor,
@@ -190,7 +190,6 @@ class AgGrid extends HTMLElement {
       },
 
       aggFuncs: CUSTOM_AGGREGATIONS,
-      getRowId: (params) => params.data?.id?.toString(),
 
       isRowSelectable: (params) => {
         return !!params.data && params.data.rowCallbackValues.isRowSelectable;
@@ -204,6 +203,14 @@ class AgGrid extends HTMLElement {
         self.dispatchEvent(selectionEvent);
       },
     };
+
+    if (this.loadAttribute("customRowId")) {
+      gridOptions.getRowId = function (params) {
+        return params.data.rowCallbackValues.rowId;
+      };
+    }
+
+    this.gridOptions = gridOptions;
 
     // Use autoHeight if no height was specified on the DOM element otherwise.
     if (!this.style.height) this.api.setDomLayout("autoHeight");

--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "mercurymedia/elm-ag-grid",
     "summary": "AgGrid integration for Elm",
     "license": "MIT",
-    "version": "8.0.0",
+    "version": "9.0.0",
     "exposed-modules": [
         "AgGrid"
     ],

--- a/examples/src/RowSelection.elm
+++ b/examples/src/RowSelection.elm
@@ -131,6 +131,7 @@ viewGrid model selection =
                 , groupSelectsChildren = True
                 , selectedIds = selection
                 , isRowSelectable = .year >> (<=) 2000 
+                , rowId = Just (.id >> String.fromInt )
                 , autoGroupColumnDef =
                     { defaultAutoGroupColumnDef
                         | cellRendererParams =

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mercurymedia/elm-ag-grid",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mercurymedia/elm-ag-grid",
-      "version": "3.1.1",
+      "version": "3.2.0",
       "license": "MIT",
       "devDependencies": {
         "@parcel/transformer-elm": "^2.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mercurymedia/elm-ag-grid",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "description": "",
   "main": "ag-grid-webcomponent/index.js",
   "files": [

--- a/src/AgGrid.elm
+++ b/src/AgGrid.elm
@@ -354,6 +354,7 @@ type alias GridConfig dataType =
     , pagination : Bool
     , quickFilterText : String
     , rowHeight : Maybe Int
+    , rowId : Maybe (dataType -> String)
     , rowGroupPanelShow : RowGroupPanelVisibility
     , rowMultiSelectWithClick : Bool
     , rowSelection : RowSelection
@@ -530,6 +531,7 @@ defaultGridConfig =
     , isRowSelectable = always True
     , pagination = False
     , quickFilterText = ""
+    , rowId = Nothing
     , rowGroupPanelShow = NeverVisible
     , rowHeight = Nothing
     , rowMultiSelectWithClick = False
@@ -1149,6 +1151,7 @@ generateGridConfigAttributes gridConfig =
             , ( "animateRows", Json.Encode.bool True )
             , ( "cacheQuickFilter", Json.Encode.bool gridConfig.cacheQuickFilter )
             , ( "columnState", columnStatesEncoder gridConfig.columnStates )
+            , ( "customRowId", Json.Encode.bool (gridConfig.rowId /= Nothing) )
             , ( "detailCellRenderer"
               , case gridConfig.detailRenderer of
                     Just _ ->
@@ -1310,6 +1313,14 @@ rowCallbackValuesEncoder : GridConfig dataType -> dataType -> Json.Encode.Value
 rowCallbackValuesEncoder gridConfig data =
     Json.Encode.object
         [ ( "isRowSelectable", Json.Encode.bool (gridConfig.isRowSelectable data) )
+        , ( "rowId"
+          , case gridConfig.rowId of
+                Just rowId ->
+                    Json.Encode.string (rowId data)
+
+                Nothing ->
+                    Json.Encode.null
+          )
         ]
 
 


### PR DESCRIPTION
I defined the `rowId` as a callback (instead of just a variable name) because this makes it more type-safe IMO.

It's easier to mess up the uniqueness necessity when just providing an attribute name because the attribute value reading is done on the package side and not so much on the user side, making it harder to spot issues - especially when the field can contain null/undefined values. 