### PR TITLE
Fix change detection for case-sensitive attributes

### DIFF
--- a/NPM_CHANGELOG.md
+++ b/NPM_CHANGELOG.md
@@ -1,5 +1,9 @@
 # NPM Changelog
 
+## [3.3.4]
+
+- Fixed change detection for case-sensitive attributes (i.e. `quickFilterText`)
+
 ## [3.3.3]
 
 - Fix: Ignore rows without data (i.e. footer) when evaluating expressions

--- a/ag-grid-webcomponent/index.js
+++ b/ag-grid-webcomponent/index.js
@@ -215,7 +215,7 @@ class AgGrid extends HTMLElement {
     } else {
       if (this._initialised) {
         // for subsequent (post gridOptions) changes
-        this._applyChange(name, parsedNewValue);
+        this._applyChange(gridPropertyName, parsedNewValue);
       } else {
         // for properties set before gridOptions is called
         this._preInitAgGridAttributes[gridPropertyName] = parsedNewValue;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mercurymedia/elm-ag-grid",
-  "version": "3.3.0",
+  "version": "3.3.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mercurymedia/elm-ag-grid",
-      "version": "3.3.0",
+      "version": "3.3.4",
       "license": "MIT",
       "devDependencies": {
         "@parcel/transformer-elm": "^2.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mercurymedia/elm-ag-grid",
-  "version": "3.3.3",
+  "version": "3.3.4",
   "description": "",
   "main": "ag-grid-webcomponent/index.js",
   "files": [


### PR DESCRIPTION
`quickFilterText` wasn't working anymore because the webcomponent change callback was populating the lowercase attribute `quickfiltertext` to the ag-grid change handler. This wasn't evaluated properly by ag-grid. Instead, we now pass the original property name `quickFilterText` to the change handler - which works again.

This might fix the issues for other attributes. But I haven't encountered any others yet.