### PR TITLE
Feature/update expressions

### DIFF
--- a/ELM_CHANGELOG.md
+++ b/ELM_CHANGELOG.md
@@ -1,5 +1,9 @@
 # Elm Changelog
 
+## [14.1.0]
+
+- Added `bool` and `list` literal for expressions.
+
 ## [14.0.0]
 
 - Added `customCellEditor` attribute on `ColumnSettings`. This allows to alter the cell editor used for the column.

--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "mercurymedia/elm-ag-grid",
     "summary": "AgGrid integration for Elm",
     "license": "MIT",
-    "version": "14.0.0",
+    "version": "14.1.0",
     "exposed-modules": [
         "AgGrid.ContextMenu",
         "AgGrid.Expression",

--- a/src/AgGrid/Expression.elm
+++ b/src/AgGrid/Expression.elm
@@ -1,7 +1,7 @@
 module AgGrid.Expression exposing
     ( Eval(..), Expression, Literal, Operator
     , or, and, eq, lte, gte, not, includes
-    , int, string, float
+    , int, string, float, list
     , value
     , encode
     )
@@ -23,7 +23,7 @@ For more information take a look at <https://github.com/mercurymedia/elm-ag-grid
 
 # Literals
 
-@docs int, string, float
+@docs int, string, float, list
 
 
 # Row values
@@ -68,6 +68,7 @@ type Literal
     = StringLiteral String
     | IntLiteral Int
     | FloatLiteral Float
+    | ListLiteral (List String)
 
 
 {-| A `Operator` take expression(s) and evaluate the result in javascript.
@@ -159,6 +160,9 @@ encodeLiteral literal =
 
         FloatLiteral f ->
             Encode.float f
+
+        ListLiteral items ->
+            Encode.list Encode.string items
 
 
 operatorToString : Operator -> String
@@ -319,3 +323,8 @@ string s =
 float : Float -> Expression
 float f =
     Lit (FloatLiteral f)
+
+
+list : List String -> Expression
+list items =
+    Lit (ListLiteral items)

--- a/src/AgGrid/Expression.elm
+++ b/src/AgGrid/Expression.elm
@@ -1,7 +1,7 @@
 module AgGrid.Expression exposing
     ( Eval(..), Expression, Literal, Operator
     , or, and, eq, lte, gte, not, includes
-    , int, string, float, list
+    , bool, int, string, float, list
     , value
     , encode
     )
@@ -23,7 +23,7 @@ For more information take a look at <https://github.com/mercurymedia/elm-ag-grid
 
 # Literals
 
-@docs int, string, float, list
+@docs bool, int, string, float, list
 
 
 # Row values
@@ -65,7 +65,8 @@ type Expression
 {-| The `Literal` type represents literals for strings, ints and floats.
 -}
 type Literal
-    = StringLiteral String
+    = BoolLiteral Bool
+    | StringLiteral String
     | IntLiteral Int
     | FloatLiteral Float
     | ListLiteral (List String)
@@ -152,6 +153,9 @@ encodeOperator operator =
 encodeLiteral : Literal -> Encode.Value
 encodeLiteral literal =
     case literal of
+        BoolLiteral b ->
+            Encode.bool b
+
         StringLiteral s ->
             Encode.string s
 
@@ -295,7 +299,7 @@ includes left right =
     Op (Includes left right)
 
 
-{-| A int Literal
+{-| An int Literal
 
     Expression.int 18
 
@@ -315,9 +319,9 @@ string s =
     Lit (StringLiteral s)
 
 
-{-| A string Literal
+{-| A float Literal
 
-    Expression.string 13.37
+    Expression.float 13.37
 
 -}
 float : Float -> Expression
@@ -325,6 +329,21 @@ float f =
     Lit (FloatLiteral f)
 
 
+{-| A string-list literal
+
+    Expression.list [ "a", "b" ]
+
+-}
 list : List String -> Expression
 list items =
     Lit (ListLiteral items)
+
+
+{-| A bool literal
+
+    Expression.bool True
+
+-}
+bool : Bool -> Expression
+bool b =
+    Lit (BoolLiteral b)


### PR DESCRIPTION
- Added `List String` literal for better usage of the `includes` operator
- Added `bool` literal to allow chaining expressions more easily

I was considering removing the `Const a` type because we should be able to reflect the same values with the available literals. But I guess it can be beneficial to enforce a certain value for some columns and attributes.