### PR TITLE
Change percentage renderer value

### DIFF
--- a/ELM_CHANGELOG.md
+++ b/ELM_CHANGELOG.md
@@ -1,5 +1,10 @@
 # Elm Changelog
 
+## [16.0.0]
+
+- BREAKING CHANGE: Removed `percentFilterValueGetter`
+- BREAKING CHANGE: `PercentRenderer` now requires the value to be the percentage (e.g. `"15" == 15%`, before this was given as decimal `0.15`). The value in the editor will also be the percentage (`15`).
+
 ## [15.1.0]
 
 - Exposing `AgGrid.ValueFormat` module

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ The latest [Elm package version](https://package.elm-lang.org/packages/mercuryme
 |  8.0.0 - 9.1.1  |       3.1.0        |
 | 10.0.0 - 11.0.0 |       3.3.0        |
 |     12.0.0      |       3.3.1        |
+|     13.0.0      |       3.3.2        |
+|   14.0.0 - \*   |     3.4.0 - \*     |
 
 ## Ag Grid Enterprise
 

--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "mercurymedia/elm-ag-grid",
     "summary": "AgGrid integration for Elm",
     "license": "MIT",
-    "version": "15.1.0",
+    "version": "16.0.0",
     "exposed-modules": [
         "AgGrid.ContextMenu",
         "AgGrid.Expression",

--- a/examples/src/Aggregation.elm
+++ b/examples/src/Aggregation.elm
@@ -176,7 +176,7 @@ viewGrid model =
               , settings = { gridSettings | aggFunc = AgGrid.SumAggregation }
               }
             , { field = "discountDE"
-              , renderer = PercentRenderer { countryCode = "de", decimalPlaces = 2 } (.de >> .discount >> Maybe.map String.fromFloat)
+              , renderer = PercentRenderer { countryCode = "de", decimalPlaces = 2 } (.de >> .discount >> Maybe.map (toPct >> String.fromFloat))
               , headerName = "Discount DE"
               , settings = { gridSettings | aggFunc = AgGrid.AvgAggregation }
               }
@@ -191,12 +191,12 @@ viewGrid model =
               , settings = { gridSettings | aggFunc = AgGrid.AvgAggregation }
               }
             , { field = "discountUS"
-              , renderer = PercentRenderer { countryCode = "us", decimalPlaces = 2 } (.us >> .discount >> Maybe.map String.fromFloat)
+              , renderer = PercentRenderer { countryCode = "us", decimalPlaces = 2 } (.us >> .discount >> Maybe.map (toPct >> String.fromFloat))
               , headerName = "Discount US"
               , settings = { gridSettings | aggFunc = AgGrid.AvgAggregation }
               }
             , { field = "minAndMax"
-              , renderer = MaybeStringRenderer (.us >> .discount >> Maybe.map String.fromFloat)
+              , renderer = MaybeStringRenderer (.us >> .discount >> Maybe.map (toPct >> String.fromFloat))
               , headerName = "Min & Max (Custom aggregation)"
               , settings = { gridSettings | aggFunc = AgGrid.CustomAggregation "Min&Max" }
               }
@@ -234,7 +234,7 @@ changeDecoder =
             Decode.succeed Cost
                 |> DecodePipeline.optional priceField (Decode.nullable Decode.string) Nothing
                 |> DecodePipeline.optional volumeField (Decode.string |> Decode.map String.toInt) Nothing
-                |> DecodePipeline.optional discountField (Decode.string |> Decode.map String.toFloat) Nothing
+                |> DecodePipeline.optional discountField (Decode.string |> Decode.map (String.toFloat >> Maybe.map toDecimal)) Nothing
     in
     Decode.succeed LineItem
         |> DecodePipeline.required "id" Decode.int
@@ -245,3 +245,13 @@ changeDecoder =
 idDecoder : Decode.Decoder Int
 idDecoder =
     Decode.field "id" Decode.int
+
+
+toPct : Float -> Float
+toPct decimal =
+    decimal * 100
+
+
+toDecimal : Float -> Float
+toDecimal pct =
+    pct / 100

--- a/src/AgGrid.elm
+++ b/src/AgGrid.elm
@@ -1514,7 +1514,7 @@ defaultColumnFilter column =
             ( NoFilter, Nothing )
 
         PercentRenderer _ _ ->
-            ( NumberFilter, Just (ValueFormat.percentFilterValueGetter column.field) )
+            ( NumberFilter, Just (ValueFormat.numberFilterValueGetter column.field) )
 
         SelectionRenderer _ _ ->
             ( SetFilter, Nothing )

--- a/src/AgGrid/ValueFormat.elm
+++ b/src/AgGrid/ValueFormat.elm
@@ -1,7 +1,7 @@
 module AgGrid.ValueFormat exposing
     ( currencyValueFormatter, decimalValueFormatter, percentValueFormatter
     , numberValueGetter
-    , booleanFilterValueGetter, numberFilterValueGetter, percentFilterValueGetter
+    , booleanFilterValueGetter, numberFilterValueGetter
     )
 
 {-| Formatting of values in the AgGrid table.
@@ -21,7 +21,7 @@ Allows to format values as currencies, decimal, and percent.
 
 # filterValueGetter
 
-@docs booleanFilterValueGetter, numberFilterValueGetter, percentFilterValueGetter
+@docs booleanFilterValueGetter, numberFilterValueGetter
 
 -}
 
@@ -121,7 +121,7 @@ percentValueFormatter { countryCode, decimalPlaces } =
 
         if (input === null || input === undefined) { return null; }
 
-        return new Intl.NumberFormat('{0}', { style: 'percent', maximumFractionDigits: {1} }).format(value)
+        return new Intl.NumberFormat('{0}', { style: 'percent', maximumFractionDigits: {1} }).format(value / 100)
     """ [ countryCode, String.fromInt <| Basics.max (decimalPlaces - 2) 0 ]
 
 
@@ -146,25 +146,6 @@ numberValueGetter fieldName =
 
 
 -- FILTER VALUE FORMATTER
-
-
-{-| Format a PERCENT cell value as DECIMAL value to be more in line with the PERCENT cell formatter.
-
-This is similar to using a normal Value Getter, but is specific to the filter.
-
-    cellValue = 0.15
-
-    percentFilterValueGetter "pctField"
-    > "15"
-
--}
-percentFilterValueGetter : String -> String
-percentFilterValueGetter field =
-    String.Interpolate.interpolate """
-        if (!data.{0}) { return null; }
-
-        return Number(data.{0} * 100)
-    """ [ field ]
 
 
 {-| Format a cell value as number.


### PR DESCRIPTION
`PercentRenderer` now requires the value to be the percentage (e.g. `"15" == 15%`, before this was given as decimal `0.15`). The value in the editor will also be the percentage (`15`).