### PR TITLE
Add maintainColumnOrder to GridConfig

### DIFF
--- a/ELM_CHANGELOG.md
+++ b/ELM_CHANGELOG.md
@@ -1,5 +1,9 @@
 # Elm Changelog
 
+## [18.0.0]
+
+- Add `maintainColumnOrder` to `GridConfig`
+
 ## [17.0.0]
 
 - BREAKING_CHANGE: Submenu actions of a custom ContextAction no longer need to be wrapped with `ChildContextAction`

--- a/src/AgGrid.elm
+++ b/src/AgGrid.elm
@@ -392,22 +392,23 @@ type alias GridConfig dataType =
     , groupIncludeTotalFooter : Bool
     , groupSelectsChildren : Bool
     , isRowSelectable : dataType -> Bool
+    , maintainColumnOrder : Bool
     , pagination : Bool
     , quickFilterText : String
+    , rowGroupPanelShow : RowGroupPanelVisibility
     , rowHeight : Maybe Int
     , rowId : Maybe (dataType -> String)
-    , rowGroupPanelShow : RowGroupPanelVisibility
     , rowMultiSelectWithClick : Bool
     , rowSelection : RowSelection
     , selectedIds : List String
     , sideBar : Sidebar
     , size : String
-    , suppressMenuHide : Bool
-    , suppressRowClickSelection : Bool
     , sizeToFitAfterFirstDataRendered : Bool
     , stopEditingWhenCellsLoseFocus : Bool
-    , themeClasses : Maybe String
+    , suppressMenuHide : Bool
+    , suppressRowClickSelection : Bool
     , suppressRowDeselection : Bool
+    , themeClasses : Maybe String
     }
 
 
@@ -586,11 +587,12 @@ defaultGridConfig =
     , groupIncludeTotalFooter = False
     , groupSelectsChildren = False
     , isRowSelectable = always True
+    , maintainColumnOrder = False
     , pagination = False
     , quickFilterText = ""
-    , rowId = Nothing
     , rowGroupPanelShow = NeverVisible
     , rowHeight = Nothing
+    , rowId = Nothing
     , rowMultiSelectWithClick = False
     , rowSelection = MultipleRowSelection
     , selectedIds = []
@@ -1258,6 +1260,7 @@ generateGridConfigAttributes gridConfig =
             , ( "groupIncludeFooter", Json.Encode.bool gridConfig.groupIncludeFooter )
             , ( "groupIncludeTotalFooter", Json.Encode.bool gridConfig.groupIncludeTotalFooter )
             , ( "groupSelectsChildren", Json.Encode.bool gridConfig.groupSelectsChildren )
+            , ( "maintainColumnOrder", Json.Encode.bool gridConfig.maintainColumnOrder)
             , ( "masterDetail"
               , Json.Encode.bool <|
                     case gridConfig.detailRenderer of


### PR DESCRIPTION
This PR add `maintainColumnOrder` to the `GridConfig` record. Details: https://www.ag-grid.com/javascript-data-grid/column-updating-definitions/#maintain-column-order