### PR TITLE
Add some aggregation options

### DIFF
--- a/src/AgGrid.elm
+++ b/src/AgGrid.elm
@@ -304,6 +304,8 @@ type alias ColumnDef dataType =
 -}
 type alias ColumnSettings =
     { aggFunc : Aggregation
+    , allowedAggFuncs : Maybe (List Aggregation)
+    , defaultAggFunc : Aggregation
     , autoHeaderHeight : Bool
     , cellClassRules : List ( String, Expression.Eval Bool )
     , checkboxSelection : Bool
@@ -520,6 +522,8 @@ Can be used when implementing column configurations for the table.
 Default column settings:
 
     { aggFunc = NoAggregation
+    , allowedAggFuncs = Nothing
+    , defaultAggFunc = SumAggregation
     , autoHeaderHeight = False
     , cellClassRules = []
     , checkboxSelection = False
@@ -566,6 +570,8 @@ Default column settings:
 defaultSettings : ColumnSettings
 defaultSettings =
     { aggFunc = NoAggregation
+    , allowedAggFuncs = Nothing
+    , defaultAggFunc = SumAggregation
     , autoHeaderHeight = False
     , cellClassRules = []
     , checkboxSelection = False
@@ -1013,6 +1019,8 @@ columnDefEncoder gridConfig columnDef =
     in
     Json.Encode.object
         [ ( "aggFunc", encodeMaybe Json.Encode.string (aggregationToString columnDef.settings.aggFunc) )
+        , ( "allowedAggFuncs", encodeMaybe (List.filterMap aggregationToString >> Json.Encode.list Json.Encode.string) columnDef.settings.allowedAggFuncs )
+        , ( "defaultAggFunc", encodeMaybe Json.Encode.string (aggregationToString columnDef.settings.defaultAggFunc) )
         , ( "autoHeaderHeight", Json.Encode.bool columnDef.settings.autoHeaderHeight )
         , ( "cellClassRules"
           , Json.Encode.object <|

--- a/tests/AgGridTest.elm
+++ b/tests/AgGridTest.elm
@@ -2,7 +2,6 @@ module AgGridTest exposing (suite)
 
 import AgGrid exposing (Aggregation(..), PinningType(..), Sorting(..), defaultGridConfig)
 import Expect
-import Html.Attributes exposing (default)
 import Test exposing (..)
 
 
@@ -84,6 +83,8 @@ suite =
                     |> (\settings ->
                             { settings
                                 | aggFunc = AgGrid.NoAggregation
+                                , allowedAggFuncs = Just [ AgGrid.SumAggregation, AgGrid.AvgAggregation ]
+                                , defaultAggFunc = AgGrid.SumAggregation
                                 , flex = Nothing
                                 , hide = False
                                 , pinned = AgGrid.Unpinned
@@ -147,6 +148,8 @@ suite =
                                 | settings =
                                     { defaultSettings
                                         | aggFunc = AgGrid.AvgAggregation
+                                        , allowedAggFuncs = Just [ AgGrid.SumAggregation, AgGrid.AvgAggregation ]
+                                        , defaultAggFunc = AgGrid.SumAggregation
                                         , flex = Just 5
                                         , hide = True
                                         , pinned = AgGrid.PinnedToLeft


### PR DESCRIPTION
Hey it's me again ;-)

This time I'd like to add some missing options for Aggregation.

This change adds `allowedAggFuncs` and `defaultAggFunc`, like in https://www.ag-grid.com/javascript-data-grid/aggregation/#api-reference

Unfortunately, this will not be backwards-compatible, as we have to modify exposed records.