### PR TITLE
Filter column events by finished and source

### DIFF
--- a/NPM_CHANGELOG.md
+++ b/NPM_CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [3.7.0]
 
 - Handling `rowClassRules` as expressions
+- Dispatch column events when `finished` is set
 
 ## [3.6.0]
 

--- a/ag-grid-webcomponent/index.js
+++ b/ag-grid-webcomponent/index.js
@@ -356,7 +356,7 @@ class AgGrid extends HTMLElement {
 
     columnEvents.map((event) =>
       this._addEventHandler(event, "columnEvents", function (params) {
-        // sizeColumnsToFit will be dispatched when the grid is scrolled horizontally
+        // column events should only dispatched when finished is set
         if (!params.finished) { return }
 
         const stateChangeEvent = columnStateChangedEvent(

--- a/ag-grid-webcomponent/index.js
+++ b/ag-grid-webcomponent/index.js
@@ -107,7 +107,7 @@ class AgGrid extends HTMLElement {
 
   set disableResizeOnScroll(disabled) {
     this._addEventHandler(
-      "onBodyScroll",
+      "onBodyScrollEnd",
       "disableResizeOnScroll",
       function (params) {
         if (!disabled) params.api.sizeColumnsToFit();
@@ -356,6 +356,9 @@ class AgGrid extends HTMLElement {
 
     columnEvents.map((event) =>
       this._addEventHandler(event, "columnEvents", function (params) {
+        // sizeColumnsToFit will be dispatched when the grid is scrolled horizontally
+        if (!params.finished) { return }
+
         const stateChangeEvent = columnStateChangedEvent(
           params,
           params.columnApi.getColumnState()


### PR DESCRIPTION
### Description

This PR improves the performance for the column events a bit by filtering the column events by `finished` and `source`. 