### PR TITLE
Add pinning to autoGroupRow

### DIFF
--- a/ELM_CHANGELOG.md
+++ b/ELM_CHANGELOG.md
@@ -1,5 +1,9 @@
 # Elm Changelog
 
+## [26.0.0]
+
+- Add `pinned` to `GridConfig.autoGroupColumnDef`
+
 ## [25.0.0]
 
 - Add `autoHeight` and `wrapText` to `ColumnSettings`

--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "mercurymedia/elm-ag-grid",
     "summary": "AgGrid integration for Elm",
     "license": "MIT",
-    "version": "25.0.0",
+    "version": "26.0.0",
     "exposed-modules": [
         "AgGrid.ContextMenu",
         "AgGrid.Expression",

--- a/examples/src/Grouping.elm
+++ b/examples/src/Grouping.elm
@@ -96,6 +96,7 @@ viewGrid model =
                         , checkbox = True
                         }
                     , resizable = True
+                    , pinned = AgGrid.PinnedToLeft
                     }
                 , rowGroupPanelShow = AgGrid.AlwaysVisible
             }

--- a/src/AgGrid.elm
+++ b/src/AgGrid.elm
@@ -460,6 +460,7 @@ type alias GridConfig dataType =
         , headerName : Maybe String
         , minWidth : Maybe Int
         , resizable : Bool
+        , pinned : PinningType
         }
     , autoSizeColumns : Bool
     , cacheQuickFilter : Bool
@@ -676,6 +677,7 @@ defaultGridConfig =
         , headerName = Nothing
         , minWidth = Nothing
         , resizable = True
+        , pinned = Unpinned
         }
     , autoSizeColumns = False
     , cacheQuickFilter = False
@@ -1532,6 +1534,7 @@ generateGridConfigAttributes gridConfig =
                             ]
                       )
                     , ( "resizable", Json.Encode.bool gridConfig.autoGroupColumnDef.resizable )
+                    , ( "pinned", encodeMaybe Json.Encode.string (pinningTypeToString gridConfig.autoGroupColumnDef.pinned) )
                     ]
               )
             , ( "autoSizeColumns", Json.Encode.bool gridConfig.autoSizeColumns )


### PR DESCRIPTION
`autoGroupColumnDef` can do a lot more than we have available right now. According to the docs[0] is is a `ColumnDef`. For now all I would need is the `pinning` so I propose to just add that in this PR. I also activated the pinning in the grouping example.

[0] https://www.ag-grid.com/angular-data-grid/grid-options/#reference-rowGrouping-autoGroupColumnDef