### PR TITLE
Support for GridConfig.suppressAggfuncInHeader

### DIFF
--- a/ELM_CHANGELOG.md
+++ b/ELM_CHANGELOG.md
@@ -1,5 +1,9 @@
 # Elm Changelog
 
+## [26.0.0]
+
+- Add `suppressAggFuncInHeader` to `GridConfig`
+
 ## [25.0.0]
 
 - Add `autoHeight` and `wrapText` to `ColumnSettings`

--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "mercurymedia/elm-ag-grid",
     "summary": "AgGrid integration for Elm",
     "license": "MIT",
-    "version": "25.0.0",
+    "version": "26.0.0",
     "exposed-modules": [
         "AgGrid.ContextMenu",
         "AgGrid.Expression",

--- a/examples/src/Grouping.elm
+++ b/examples/src/Grouping.elm
@@ -98,6 +98,7 @@ viewGrid model =
                     , resizable = True
                     }
                 , rowGroupPanelShow = AgGrid.AlwaysVisible
+                , suppressAggFuncInHeader = True
             }
 
         gridSettings =

--- a/src/AgGrid.elm
+++ b/src/AgGrid.elm
@@ -494,6 +494,7 @@ type alias GridConfig dataType =
     , size : String
     , sizeToFitAfterFirstDataRendered : Bool
     , stopEditingWhenCellsLoseFocus : Bool
+    , suppressAggFuncInHeader : Bool
     , suppressMenuHide : Bool
     , suppressRowClickSelection : Bool
     , suppressRowDeselection : Bool
@@ -659,6 +660,7 @@ Can be used when implementing the grid.
         , size = "65vh"
         , sizeToFitAfterFirstDataRendered = True
         , stopEditingWhenCellsLoseFocus = True
+        , suppressAggFuncInHeader = False
         , suppressMenuHide = False
         , suppressRowClickSelection = False
         , suppressRowDeselection = False
@@ -714,6 +716,7 @@ defaultGridConfig =
     , size = "65vh"
     , sizeToFitAfterFirstDataRendered = True
     , stopEditingWhenCellsLoseFocus = True
+    , suppressAggFuncInHeader = False
     , suppressMenuHide = False
     , suppressRowClickSelection = False
     , suppressRowDeselection = False
@@ -1632,6 +1635,7 @@ generateGridConfigAttributes gridConfig =
               )
             , ( "sizeToFitAfterFirstDataRendered", Json.Encode.bool gridConfig.sizeToFitAfterFirstDataRendered )
             , ( "stopEditingWhenCellsLoseFocus", Json.Encode.bool gridConfig.stopEditingWhenCellsLoseFocus )
+            , ( "suppressAggFuncInHeader", Json.Encode.bool gridConfig.suppressAggFuncInHeader )
             , ( "suppressMenuHide", Json.Encode.bool gridConfig.suppressMenuHide )
             , ( "suppressRowClickSelection", Json.Encode.bool gridConfig.suppressRowClickSelection )
             , ( "suppressRowDeselection", Json.Encode.bool gridConfig.suppressRowDeselection )


### PR DESCRIPTION
Adds support for https://www.ag-grid.com/javascript-data-grid/aggregation/#reference-rowPivoting-suppressAggFuncInHeader

Also added to the grouping example for demonstration.