### PR TITLE
Support lockpinned

### DIFF
--- a/ELM_CHANGELOG.md
+++ b/ELM_CHANGELOG.md
@@ -1,5 +1,9 @@
 # Elm Changelog
 
+## [27.0.0]
+
+- Add `lockPinned` to `ColumnSettings`
+
 ## [26.0.0]
 
 - Add `columnHoverHighlight` and `rowHoverHighlight` to `GridConfig`

--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "mercurymedia/elm-ag-grid",
     "summary": "AgGrid integration for Elm",
     "license": "MIT",
-    "version": "26.0.0",
+    "version": "27.0.0",
     "exposed-modules": [
         "AgGrid.ContextMenu",
         "AgGrid.Expression",

--- a/src/AgGrid.elm
+++ b/src/AgGrid.elm
@@ -332,6 +332,7 @@ type alias ColumnSettings =
     , lockPosition : LockPosition
     , minWidth : Maybe Int
     , pinned : PinningType
+    , lockPinned : Bool
     , pivot : Bool
     , pivotIndex : Maybe Int
     , resizable : Bool
@@ -554,6 +555,7 @@ Default column settings:
     , floatingFilter = False
     , headerCheckboxSelection = False
     , hide = False
+    , lockPinned = False
     , lockPosition = NoPositionLock
     , minWidth = Nothing
     , pinned = Unpinned
@@ -607,6 +609,7 @@ defaultSettings =
     , lockPosition = NoPositionLock
     , minWidth = Nothing
     , pinned = Unpinned
+    , lockPinned = False
     , pivot = False
     , pivotIndex = Nothing
     , resizable = True
@@ -1187,6 +1190,7 @@ columnDefEncoder gridConfig columnDef =
           )
         , ( "minWidth", encodeMaybe Json.Encode.int columnDef.settings.minWidth )
         , ( "pinned", encodeMaybe Json.Encode.string (pinningTypeToString columnDef.settings.pinned) )
+        , ( "lockPinned", Json.Encode.bool columnDef.settings.lockPinned )
         , ( "pivot", Json.Encode.bool columnDef.settings.pivot )
         , ( "pivotIndex", encodeMaybe Json.Encode.int columnDef.settings.pivotIndex )
         , ( "resizable", Json.Encode.bool columnDef.settings.resizable )


### PR DESCRIPTION
These changes add support for the `lockPinned` column attribute. See also https://www.ag-grid.com/javascript-data-grid/column-pinning/#lock-pinned