### PR TITLE
Update NPM package to use Ag Grid 31.1.0

### DIFF
--- a/NPM_CHANGELOG.md
+++ b/NPM_CHANGELOG.md
@@ -1,5 +1,49 @@
 # NPM Changelog
 
+## [4.0.0]
+
+- Updates AG Grid to 31.1.x
+- AG Grid dependencies now via modules (https://www.ag-grid.com/javascript-data-grid/modules/). If you are upgrading from an older version, you need to change your NPM dependencies to use the module-based imports. Also check your Browser console for warnings from AG Grid.
+
+   - Replace ag-grid-community dependency with @ag-grid-community/core
+   - Replace ag-grid-enterprise dependency with @ag-grid-enterprise/core
+   - Add module-based dependencies as needed:
+     ```json
+       "@ag-grid-community/styles": "^31.1.0",
+       "@ag-grid-community/client-side-row-model": "^31.1.0",
+       "@ag-grid-enterprise/column-tool-panel": "^31.1.0",
+       "@ag-grid-enterprise/filter-tool-panel": "^31.1.0",
+       "@ag-grid-enterprise/menu": "^31.1.0",
+       "@ag-grid-enterprise/range-selection": "^31.1.0",
+       "@ag-grid-enterprise/rich-select": "^31.1.0",
+       "@ag-grid-enterprise/row-grouping": "^31.1.0",
+       "@ag-grid-enterprise/side-bar": "^31.1.0",
+     ```
+   - Register AgGrid components as necessary:
+     ```js
+       import { ModuleRegistry } from '@ag-grid-community/core'
+       import { ClientSideRowModelModule } from '@ag-grid-community/client-side-row-model'
+       import { LicenseManager } from '@ag-grid-enterprise/core'
+       import { ColumnsToolPanelModule } from '@ag-grid-enterprise/column-tool-panel'
+       import { FiltersToolPanelModule } from '@ag-grid-enterprise/filter-tool-panel'
+       import { MenuModule } from '@ag-grid-enterprise/menu'
+       import { RangeSelectionModule } from '@ag-grid-enterprise/range-selection'
+       import { RichSelectModule } from '@ag-grid-enterprise/rich-select'
+       import { RowGroupingModule } from '@ag-grid-enterprise/row-grouping'
+       import { SideBarModule } from '@ag-grid-enterprise/side-bar'
+
+       ModuleRegistry.registerModules([
+         ClientSideRowModelModule,
+         ColumnsToolPanelModule,
+         FiltersToolPanelModule,
+         MenuModule,
+         RangeSelectionModule,
+         RichSelectModule,
+         RowGroupingModule,
+         SideBarModule
+       ]);
+     ```
+
 ## [3.7.1]
 
 - Explicitly check in column events for `finished === false`

--- a/README.md
+++ b/README.md
@@ -27,7 +27,18 @@ new ElmAgGrid();
 Elm.Main.init({ node: document.getElementById("app") });
 ```
 
-**Note:** The package requires at least `ag-grid-community` to be available in the project.
+For most features of AG Grid it is necessary to install modules and register them:
+
+```js
+import { ModuleRegistry } from '@ag-grid-community/core'
+import { ClientSideRowModelModule } from '@ag-grid-community/client-side-row-model'
+
+ModuleRegistry.registerModules([
+  ClientSideRowModelModule
+]);
+```
+
+AG Grid will print warnings into the browser console if modules are missing. For a full list of modules, see https://www.ag-grid.com/javascript-data-grid/modules/.
 
 ## Package version requirements
 
@@ -47,16 +58,16 @@ The latest [Elm package version](https://package.elm-lang.org/packages/mercuryme
 | 14.0.0 - 18.0.0 |   3.4.0 - 3.4.2    |
 | 19.0.0 - 22.0.0 |       3.5.0        |
 | 23.0.0 - 23.1.0 |       3.6.0        |
-|   24.0.0 - \*   |   3.7.0 - 3.7.1    |
+|   24.0.0 - \*   |   3.7.0 - 4.0.0    |
 
 ## Ag Grid Enterprise
 
-The `elm-ag-grid` package uses Ag Grid Enterprise features. To enable them install the `ag-grid-enterprise` package and activate it by setting the license key. See the [official Ag Grid documentation](http://54.222.217.254/javascript-grid-set-license/) for further details.
+The `elm-ag-grid` package uses Ag Grid Enterprise features. To enable them install the `@ag-grid-enterprise/core` package and activate it by setting the license key. See the [official Ag Grid documentation](http://54.222.217.254/javascript-grid-set-license/) for further details.
 
 ```js
-import * as AgGridEnterprise from "ag-grid-enterprise";
+import { LicenseManager } from '@ag-grid-enterprise/core'
 
-AgGridEnterprise.LicenseManager.setLicenseKey("YOUR-LICENSE-KEY");
+LicenseManager.setLicenseKey("YOUR LICENSE KEY");
 ```
 
 ## Themes

--- a/examples/index.js
+++ b/examples/index.js
@@ -1,17 +1,38 @@
 import "@webcomponents/custom-elements";
-import * as AgGridEnterprise from "ag-grid-enterprise";
 
-// This would usually be the pacakge import
+// This would usually be the package import
 // import ElmAgGrid from "@mercurymedia/elm-ag-grid";
 import ElmAgGrid from "../ag-grid-webcomponent";
 import { Elm } from "./src/Main.elm";
 
-import "ag-grid-community/styles/ag-grid.css";
-import "ag-grid-community/styles/ag-theme-balham.css";
-import "./styles/ag_grid_custom.css";
+import { ModuleRegistry } from '@ag-grid-community/core'
+import { ClientSideRowModelModule } from '@ag-grid-community/client-side-row-model'
+import { LicenseManager } from '@ag-grid-enterprise/core'
+import { ColumnsToolPanelModule } from '@ag-grid-enterprise/column-tool-panel'
+import { FiltersToolPanelModule } from '@ag-grid-enterprise/filter-tool-panel'
+import { MenuModule } from '@ag-grid-enterprise/menu'
+import { RangeSelectionModule } from '@ag-grid-enterprise/range-selection'
+import { RichSelectModule } from '@ag-grid-enterprise/rich-select'
+import { RowGroupingModule } from '@ag-grid-enterprise/row-grouping'
+import { SideBarModule } from '@ag-grid-enterprise/side-bar'
 
-// For AG Grid Enterprise you can set license key by calling:
-// AgGridEnterprise.LicenseManager.setLicenseKey("YOUR-LICENSE-KEY");
+// For AG Grid Enterprise features set your license key here:
+// LicenseManager.setLicenseKey("YOUR LICENSE KEY");
+
+ModuleRegistry.registerModules([
+  ClientSideRowModelModule,
+  ColumnsToolPanelModule,
+  FiltersToolPanelModule,
+  MenuModule,
+  RangeSelectionModule,
+  RichSelectModule,
+  RowGroupingModule,
+  SideBarModule
+]);
+
+import "@ag-grid-community/styles/ag-grid.css";
+import "@ag-grid-community/styles/ag-theme-balham.css";
+import "./styles/ag_grid_custom.css";
 
 // Component import
 import ButtonRenderer from "./src/Components/Button.elm";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,26 +1,135 @@
 {
   "name": "@mercurymedia/elm-ag-grid",
-  "version": "3.6.0",
+  "version": "4.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mercurymedia/elm-ag-grid",
-      "version": "3.6.0",
+      "version": "4.0.0",
       "license": "MIT",
       "devDependencies": {
+        "@ag-grid-community/client-side-row-model": "^31.1.0",
+        "@ag-grid-community/styles": "^31.1.0",
+        "@ag-grid-enterprise/column-tool-panel": "^31.1.0",
+        "@ag-grid-enterprise/filter-tool-panel": "^31.1.0",
+        "@ag-grid-enterprise/menu": "^31.1.0",
+        "@ag-grid-enterprise/range-selection": "^31.1.0",
+        "@ag-grid-enterprise/rich-select": "^31.1.0",
+        "@ag-grid-enterprise/row-grouping": "^31.1.0",
+        "@ag-grid-enterprise/side-bar": "^31.1.0",
         "@parcel/transformer-elm": "^2.3.2",
         "@webcomponents/custom-elements": "^1.5.0",
-        "ag-grid-community": "^29.1.0",
-        "ag-grid-enterprise": "^29.1.0",
         "elm": "^0.19.1-5",
         "elm-format": "^0.8.7",
         "elm-test": "^0.19.1-revision12",
         "parcel": "^2.3.2"
       },
       "peerDependencies": {
-        "ag-grid-community": "^29.1.0",
-        "ag-grid-enterprise": "^29.1.0"
+        "@ag-grid-community/core": "^31.1.0"
+      }
+    },
+    "node_modules/@ag-grid-community/client-side-row-model": {
+      "version": "31.1.1",
+      "resolved": "https://registry.npmjs.org/@ag-grid-community/client-side-row-model/-/client-side-row-model-31.1.1.tgz",
+      "integrity": "sha512-KBSPaEJ1q97xooJd7U6W8PUfzUDecnsvE+Y05Xg/s6i61fLKyDTxDVJB/kETxdST0+T8FgjFMaPjY0hAZBOhWg==",
+      "dev": true,
+      "dependencies": {
+        "@ag-grid-community/core": "31.1.1"
+      }
+    },
+    "node_modules/@ag-grid-community/core": {
+      "version": "31.1.1",
+      "resolved": "https://registry.npmjs.org/@ag-grid-community/core/-/core-31.1.1.tgz",
+      "integrity": "sha512-WFN3yXpFR0uMJQZak6x4kzLl7nJPrrorUWf/KWH4ToP6PMZcc6cKT3jge3bJ0SBkzs2m7oQGnmi8rfTaHuXI4Q=="
+    },
+    "node_modules/@ag-grid-community/styles": {
+      "version": "31.1.1",
+      "resolved": "https://registry.npmjs.org/@ag-grid-community/styles/-/styles-31.1.1.tgz",
+      "integrity": "sha512-Q44beV3vD1jydB0smro9+nJY9g60uSjQ+cM8cHEIS9gDCG/37WiabdtQybJceeIHbne51MJPtOAa89y/TfnbQg==",
+      "dev": true
+    },
+    "node_modules/@ag-grid-enterprise/column-tool-panel": {
+      "version": "31.1.1",
+      "resolved": "https://registry.npmjs.org/@ag-grid-enterprise/column-tool-panel/-/column-tool-panel-31.1.1.tgz",
+      "integrity": "sha512-AiwjaCj0iX9V4+Xw4R2sQlJaCMAyh80bclgasIODKPDr98HZ76rAWHSXqdc37TAwHpFIEYeOsS98UewjvFJUBA==",
+      "dev": true,
+      "dependencies": {
+        "@ag-grid-community/core": "31.1.1",
+        "@ag-grid-enterprise/core": "31.1.1",
+        "@ag-grid-enterprise/row-grouping": "31.1.1",
+        "@ag-grid-enterprise/side-bar": "31.1.1"
+      }
+    },
+    "node_modules/@ag-grid-enterprise/core": {
+      "version": "31.1.1",
+      "resolved": "https://registry.npmjs.org/@ag-grid-enterprise/core/-/core-31.1.1.tgz",
+      "integrity": "sha512-jbLXQqfgZCTh1FQ6Dbsbmn/+EWAhPu+4stECLxdP3zVXPxJh1vOw717GjGQrduo5jWWdncj7mC9zOMSLMyzW1Q==",
+      "dev": true,
+      "dependencies": {
+        "@ag-grid-community/core": "31.1.1"
+      }
+    },
+    "node_modules/@ag-grid-enterprise/filter-tool-panel": {
+      "version": "31.1.1",
+      "resolved": "https://registry.npmjs.org/@ag-grid-enterprise/filter-tool-panel/-/filter-tool-panel-31.1.1.tgz",
+      "integrity": "sha512-Txtc3G0iL/qIbceBPT8lbyjAOgASKPGtBSI9yxoHmK/BUzK3FpyDTDE2ziRfqX02JODnkFoSXmNVdRJSn8jqgg==",
+      "dev": true,
+      "dependencies": {
+        "@ag-grid-community/core": "31.1.1",
+        "@ag-grid-enterprise/core": "31.1.1",
+        "@ag-grid-enterprise/side-bar": "31.1.1"
+      }
+    },
+    "node_modules/@ag-grid-enterprise/menu": {
+      "version": "31.1.1",
+      "resolved": "https://registry.npmjs.org/@ag-grid-enterprise/menu/-/menu-31.1.1.tgz",
+      "integrity": "sha512-BhLKOliv2An91c5jQKKTwdLT7b+qw1zwqc79XoLCY52ld8swhH3ckbdkVibXv20uNHDYvSfG9QrTOH6MfaZ0nQ==",
+      "dev": true,
+      "dependencies": {
+        "@ag-grid-community/core": "31.1.1",
+        "@ag-grid-enterprise/column-tool-panel": "31.1.1",
+        "@ag-grid-enterprise/core": "31.1.1"
+      }
+    },
+    "node_modules/@ag-grid-enterprise/range-selection": {
+      "version": "31.1.1",
+      "resolved": "https://registry.npmjs.org/@ag-grid-enterprise/range-selection/-/range-selection-31.1.1.tgz",
+      "integrity": "sha512-7W3HXdkTVgnq6kmd03ptJLx9QYphrQPWg0RMXXFzmKLS4Gprz6kw3HW8aaO+acvvvLn7hBWKFJ8hELS+fuA5tg==",
+      "dev": true,
+      "dependencies": {
+        "@ag-grid-community/core": "31.1.1",
+        "@ag-grid-enterprise/core": "31.1.1"
+      }
+    },
+    "node_modules/@ag-grid-enterprise/rich-select": {
+      "version": "31.1.1",
+      "resolved": "https://registry.npmjs.org/@ag-grid-enterprise/rich-select/-/rich-select-31.1.1.tgz",
+      "integrity": "sha512-RNjA+1nk9Wa4rHdE5yqLi+vVjkGeJ4LBEh96qGXdjREV7rIOOGEV5q5/aiPUPxaBbbxqxCu4na6A8EUWe6fPiw==",
+      "dev": true,
+      "dependencies": {
+        "@ag-grid-community/core": "31.1.1",
+        "@ag-grid-enterprise/core": "31.1.1"
+      }
+    },
+    "node_modules/@ag-grid-enterprise/row-grouping": {
+      "version": "31.1.1",
+      "resolved": "https://registry.npmjs.org/@ag-grid-enterprise/row-grouping/-/row-grouping-31.1.1.tgz",
+      "integrity": "sha512-CcyF8vzNEBzwEX4WuMYJ6hQ+F7RFoYqdYDyUj01Vz/dnLiZummT2a9bAdLXYCaNDg7fyrsjnqchiTv8g06qsmA==",
+      "dev": true,
+      "dependencies": {
+        "@ag-grid-community/core": "31.1.1",
+        "@ag-grid-enterprise/core": "31.1.1"
+      }
+    },
+    "node_modules/@ag-grid-enterprise/side-bar": {
+      "version": "31.1.1",
+      "resolved": "https://registry.npmjs.org/@ag-grid-enterprise/side-bar/-/side-bar-31.1.1.tgz",
+      "integrity": "sha512-MjkNBaI4VOoiHzwmBm/qi7DoxzDXOBBGr4xA5Crmr7WJZ5f947P7bXM5cwJfu8pfUegyMgiKn0k/7FB2usUUZg==",
+      "dev": true,
+      "dependencies": {
+        "@ag-grid-community/core": "31.1.1",
+        "@ag-grid-enterprise/core": "31.1.1"
       }
     },
     "node_modules/@avh4/elm-format-darwin-arm64": {
@@ -1295,18 +1404,6 @@
       "engines": {
         "node": ">=0.4.0"
       }
-    },
-    "node_modules/ag-grid-community": {
-      "version": "29.1.0",
-      "resolved": "https://registry.npmjs.org/ag-grid-community/-/ag-grid-community-29.1.0.tgz",
-      "integrity": "sha512-QJZi1qP7fpK/sxXbEFZWR3/Jf3HVRK0Xm3Tw55tn0ehNdkuSxRBOmOvjE3lPWqgRlT2rcL1xmjdqM4mpB1fobQ==",
-      "dev": true
-    },
-    "node_modules/ag-grid-enterprise": {
-      "version": "29.1.0",
-      "resolved": "https://registry.npmjs.org/ag-grid-enterprise/-/ag-grid-enterprise-29.1.0.tgz",
-      "integrity": "sha512-0SQqjZ2KOFYKmjNICIii24CItenFOA+Jkkf/v/RpLND9ZttWN2/RqtRcw9V+GCuFhEpaDBZ1Q+nx4q5mHcVMRQ==",
-      "dev": true
     },
     "node_modules/ajv": {
       "version": "6.12.6",
@@ -3985,6 +4082,109 @@
     }
   },
   "dependencies": {
+    "@ag-grid-community/client-side-row-model": {
+      "version": "31.1.1",
+      "resolved": "https://registry.npmjs.org/@ag-grid-community/client-side-row-model/-/client-side-row-model-31.1.1.tgz",
+      "integrity": "sha512-KBSPaEJ1q97xooJd7U6W8PUfzUDecnsvE+Y05Xg/s6i61fLKyDTxDVJB/kETxdST0+T8FgjFMaPjY0hAZBOhWg==",
+      "dev": true,
+      "requires": {
+        "@ag-grid-community/core": "31.1.1"
+      }
+    },
+    "@ag-grid-community/core": {
+      "version": "31.1.1",
+      "resolved": "https://registry.npmjs.org/@ag-grid-community/core/-/core-31.1.1.tgz",
+      "integrity": "sha512-WFN3yXpFR0uMJQZak6x4kzLl7nJPrrorUWf/KWH4ToP6PMZcc6cKT3jge3bJ0SBkzs2m7oQGnmi8rfTaHuXI4Q=="
+    },
+    "@ag-grid-community/styles": {
+      "version": "31.1.1",
+      "resolved": "https://registry.npmjs.org/@ag-grid-community/styles/-/styles-31.1.1.tgz",
+      "integrity": "sha512-Q44beV3vD1jydB0smro9+nJY9g60uSjQ+cM8cHEIS9gDCG/37WiabdtQybJceeIHbne51MJPtOAa89y/TfnbQg==",
+      "dev": true
+    },
+    "@ag-grid-enterprise/column-tool-panel": {
+      "version": "31.1.1",
+      "resolved": "https://registry.npmjs.org/@ag-grid-enterprise/column-tool-panel/-/column-tool-panel-31.1.1.tgz",
+      "integrity": "sha512-AiwjaCj0iX9V4+Xw4R2sQlJaCMAyh80bclgasIODKPDr98HZ76rAWHSXqdc37TAwHpFIEYeOsS98UewjvFJUBA==",
+      "dev": true,
+      "requires": {
+        "@ag-grid-community/core": "31.1.1",
+        "@ag-grid-enterprise/core": "31.1.1",
+        "@ag-grid-enterprise/row-grouping": "31.1.1",
+        "@ag-grid-enterprise/side-bar": "31.1.1"
+      }
+    },
+    "@ag-grid-enterprise/core": {
+      "version": "31.1.1",
+      "resolved": "https://registry.npmjs.org/@ag-grid-enterprise/core/-/core-31.1.1.tgz",
+      "integrity": "sha512-jbLXQqfgZCTh1FQ6Dbsbmn/+EWAhPu+4stECLxdP3zVXPxJh1vOw717GjGQrduo5jWWdncj7mC9zOMSLMyzW1Q==",
+      "dev": true,
+      "requires": {
+        "@ag-grid-community/core": "31.1.1"
+      }
+    },
+    "@ag-grid-enterprise/filter-tool-panel": {
+      "version": "31.1.1",
+      "resolved": "https://registry.npmjs.org/@ag-grid-enterprise/filter-tool-panel/-/filter-tool-panel-31.1.1.tgz",
+      "integrity": "sha512-Txtc3G0iL/qIbceBPT8lbyjAOgASKPGtBSI9yxoHmK/BUzK3FpyDTDE2ziRfqX02JODnkFoSXmNVdRJSn8jqgg==",
+      "dev": true,
+      "requires": {
+        "@ag-grid-community/core": "31.1.1",
+        "@ag-grid-enterprise/core": "31.1.1",
+        "@ag-grid-enterprise/side-bar": "31.1.1"
+      }
+    },
+    "@ag-grid-enterprise/menu": {
+      "version": "31.1.1",
+      "resolved": "https://registry.npmjs.org/@ag-grid-enterprise/menu/-/menu-31.1.1.tgz",
+      "integrity": "sha512-BhLKOliv2An91c5jQKKTwdLT7b+qw1zwqc79XoLCY52ld8swhH3ckbdkVibXv20uNHDYvSfG9QrTOH6MfaZ0nQ==",
+      "dev": true,
+      "requires": {
+        "@ag-grid-community/core": "31.1.1",
+        "@ag-grid-enterprise/column-tool-panel": "31.1.1",
+        "@ag-grid-enterprise/core": "31.1.1"
+      }
+    },
+    "@ag-grid-enterprise/range-selection": {
+      "version": "31.1.1",
+      "resolved": "https://registry.npmjs.org/@ag-grid-enterprise/range-selection/-/range-selection-31.1.1.tgz",
+      "integrity": "sha512-7W3HXdkTVgnq6kmd03ptJLx9QYphrQPWg0RMXXFzmKLS4Gprz6kw3HW8aaO+acvvvLn7hBWKFJ8hELS+fuA5tg==",
+      "dev": true,
+      "requires": {
+        "@ag-grid-community/core": "31.1.1",
+        "@ag-grid-enterprise/core": "31.1.1"
+      }
+    },
+    "@ag-grid-enterprise/rich-select": {
+      "version": "31.1.1",
+      "resolved": "https://registry.npmjs.org/@ag-grid-enterprise/rich-select/-/rich-select-31.1.1.tgz",
+      "integrity": "sha512-RNjA+1nk9Wa4rHdE5yqLi+vVjkGeJ4LBEh96qGXdjREV7rIOOGEV5q5/aiPUPxaBbbxqxCu4na6A8EUWe6fPiw==",
+      "dev": true,
+      "requires": {
+        "@ag-grid-community/core": "31.1.1",
+        "@ag-grid-enterprise/core": "31.1.1"
+      }
+    },
+    "@ag-grid-enterprise/row-grouping": {
+      "version": "31.1.1",
+      "resolved": "https://registry.npmjs.org/@ag-grid-enterprise/row-grouping/-/row-grouping-31.1.1.tgz",
+      "integrity": "sha512-CcyF8vzNEBzwEX4WuMYJ6hQ+F7RFoYqdYDyUj01Vz/dnLiZummT2a9bAdLXYCaNDg7fyrsjnqchiTv8g06qsmA==",
+      "dev": true,
+      "requires": {
+        "@ag-grid-community/core": "31.1.1",
+        "@ag-grid-enterprise/core": "31.1.1"
+      }
+    },
+    "@ag-grid-enterprise/side-bar": {
+      "version": "31.1.1",
+      "resolved": "https://registry.npmjs.org/@ag-grid-enterprise/side-bar/-/side-bar-31.1.1.tgz",
+      "integrity": "sha512-MjkNBaI4VOoiHzwmBm/qi7DoxzDXOBBGr4xA5Crmr7WJZ5f947P7bXM5cwJfu8pfUegyMgiKn0k/7FB2usUUZg==",
+      "dev": true,
+      "requires": {
+        "@ag-grid-community/core": "31.1.1",
+        "@ag-grid-enterprise/core": "31.1.1"
+      }
+    },
     "@avh4/elm-format-darwin-arm64": {
       "version": "0.8.7-2",
       "resolved": "https://registry.npmjs.org/@avh4/elm-format-darwin-arm64/-/elm-format-darwin-arm64-0.8.7-2.tgz",
@@ -4801,18 +5001,6 @@
       "version": "8.7.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
       "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
-      "dev": true
-    },
-    "ag-grid-community": {
-      "version": "29.1.0",
-      "resolved": "https://registry.npmjs.org/ag-grid-community/-/ag-grid-community-29.1.0.tgz",
-      "integrity": "sha512-QJZi1qP7fpK/sxXbEFZWR3/Jf3HVRK0Xm3Tw55tn0ehNdkuSxRBOmOvjE3lPWqgRlT2rcL1xmjdqM4mpB1fobQ==",
-      "dev": true
-    },
-    "ag-grid-enterprise": {
-      "version": "29.1.0",
-      "resolved": "https://registry.npmjs.org/ag-grid-enterprise/-/ag-grid-enterprise-29.1.0.tgz",
-      "integrity": "sha512-0SQqjZ2KOFYKmjNICIii24CItenFOA+Jkkf/v/RpLND9ZttWN2/RqtRcw9V+GCuFhEpaDBZ1Q+nx4q5mHcVMRQ==",
       "dev": true
     },
     "ajv": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mercurymedia/elm-ag-grid",
-  "version": "3.7.1",
+  "version": "4.0.0",
   "description": "",
   "main": "ag-grid-webcomponent/index.js",
   "files": [
@@ -18,14 +18,20 @@
   "repository": "git://github.com/mercurymedia/elm-ag-grid.git",
   "license": "MIT",
   "peerDependencies": {
-    "ag-grid-community": "^29.1.0",
-    "ag-grid-enterprise": "^29.1.0"
+    "@ag-grid-community/core": "^31.1.0"
   },
   "devDependencies": {
     "@parcel/transformer-elm": "^2.3.2",
+    "@ag-grid-community/styles": "^31.1.0",
+    "@ag-grid-community/client-side-row-model": "^31.1.0",
+    "@ag-grid-enterprise/column-tool-panel": "^31.1.0",
+    "@ag-grid-enterprise/filter-tool-panel": "^31.1.0",
+    "@ag-grid-enterprise/menu": "^31.1.0",
+    "@ag-grid-enterprise/range-selection": "^31.1.0",
+    "@ag-grid-enterprise/rich-select": "^31.1.0",
+    "@ag-grid-enterprise/row-grouping": "^31.1.0",
+    "@ag-grid-enterprise/side-bar": "^31.1.0",
     "@webcomponents/custom-elements": "^1.5.0",
-    "ag-grid-community": "^29.1.0",
-    "ag-grid-enterprise": "^29.1.0",
     "elm": "^0.19.1-5",
     "elm-format": "^0.8.7",
     "elm-test": "^0.19.1-revision12",


### PR DESCRIPTION
This change updates the NPM package to use AG Grid 31.1.x

Notable proposed changes:

* The custom element wrapper code got simplified due to simplification in AG Grid's API
* AG Grid changed how internal modules are set up and also integrated big new features (like embedded charts) we we do not yet support. So it makes sense to no longer include the packaged versions but the modules to we can only import the needed parts.
* Since users upgrading to this package version have to change their embedding code, the version bump is major.

Also Closes https://github.com/mercurymedia/elm-ag-grid/issues/3