### PR TITLE
Move table state into elm app

### DIFF
--- a/ag-grid-webcomponent/index.js
+++ b/ag-grid-webcomponent/index.js
@@ -264,6 +264,7 @@ class AgGrid extends HTMLElement {
     const self = this;
 
     let gridOptions = {
+      readOnlyEdit: true,
       components: {
         ...cellRenderer,
         ...cellEditor,
@@ -303,7 +304,18 @@ class AgGrid extends HTMLElement {
         return !!params.data && params.data.rowCallbackValues.isRowSelectable;
       },
 
-      onSelectionChanged: function (event) {
+      onCellEditRequest: function(e) {
+        let newData = Object.assign({}, e.data);
+        newData[e.column.colId] = e.newValue;
+        const editEvent = new CustomEvent("editRequest", {
+          detail: {
+            data: newData
+          }
+        });
+        self.dispatchEvent(editEvent);
+      },
+
+      onSelectionChanged: function(event) {
         const nodes = event.api.getSelectedNodes();
         const selectionEvent = new CustomEvent("selectionChanged", {
           detail: { nodes },

--- a/src/AgGrid.elm
+++ b/src/AgGrid.elm
@@ -931,7 +931,7 @@ onCellChanged dataDecoder toMsg =
     cellUpdateDecoder
         |> Decode.map (Decode.decodeValue dataDecoder)
         |> Decode.map toMsg
-        |> Html.Events.on "cellvaluechanged"
+        |> Html.Events.on "editRequest"
 
 
 {-| Detect click events on cells.
@@ -1838,7 +1838,7 @@ encodeData gridConfig columns data =
 
 cellUpdateDecoder : Decoder Decode.Value
 cellUpdateDecoder =
-    Decode.at [ "agGridDetails", "data" ] Decode.value
+    Decode.at [ "detail", "data" ] Decode.value
 
 
 defaultColumnFilter : ColumnDef dataType -> ( FilterType, Maybe String )


### PR DESCRIPTION
By using a read-only grid and only updating the grid when the state in the elm app changes. This way it behaves more like a normal elm module and adheres to the elm architecture.