### PR TITLE
Expose API backwards compatible

### DIFF
--- a/NPM_CHANGELOG.md
+++ b/NPM_CHANGELOG.md
@@ -1,5 +1,9 @@
 # NPM Changelog
 
+## [4.0.1]
+
+- AgGrid API now exposed again as `<custom-element>.api` as it was before 4.0.0
+
 ## [4.0.0]
 
 - Enabled `readOnlyEdit` in AgGrid and sending `editRequest` events to notify about changes

--- a/ag-grid-webcomponent/index.js
+++ b/ag-grid-webcomponent/index.js
@@ -64,7 +64,7 @@ class AgGrid extends HTMLElement {
     if (!this._initialised) {
       // prevent instantiating multiple grids
       let gridParams = { globalEventListener };
-      this._api = createGrid(this, mergedOptions, gridParams);
+      this.api = createGrid(this, mergedOptions, gridParams);
 
       this._initialised = true;
 
@@ -96,7 +96,7 @@ class AgGrid extends HTMLElement {
   }
 
   set columnState(state) {
-    this._api.applyColumnState({ state: state, applyOrder: true });
+    this.api.applyColumnState({ state: state, applyOrder: true });
   }
 
   set disableResizeOnScroll(disabled) {
@@ -110,7 +110,7 @@ class AgGrid extends HTMLElement {
   }
 
   set filterState(state) {
-    this._api.setFilterModel(state);
+    this.api.setFilterModel(state);
   }
 
   set sizeToFitAfterFirstDataRendered(sizeToFit) {
@@ -127,15 +127,15 @@ class AgGrid extends HTMLElement {
     this._applyChange("rowData", data);
 
     if (data == []) {
-      this._api.showNoRowsOverlay();
+      this.api.showNoRowsOverlay();
     }
   }
 
   set selectedIds(selectedIds) {
     if (selectedIds.length == 0) {
-      this._api.deselectAll();
+      this.api.deselectAll();
     } else {
-      this._api.forEachNode(function (node) {
+      this.api.forEachNode(function (node) {
         const selected = selectedIds.includes(node.id);
         node.setSelected(selected);
       });
@@ -153,7 +153,7 @@ class AgGrid extends HTMLElement {
         ),
       };
     }
-    this._api.updateGridOptions({columnDefs: defs.map(applyCallbacks)});
+    this.api.updateGridOptions({columnDefs: defs.map(applyCallbacks)});
   }
 
   set getContextMenuItems(data) {
@@ -206,7 +206,7 @@ class AgGrid extends HTMLElement {
   }
 
   _applyChange(propertyName, newValue) {
-    this._api.setGridOption(propertyName, newValue);
+    this.api.setGridOption(propertyName, newValue);
   }
 
   _addEventHandler(eventName, type, callback) {
@@ -215,7 +215,7 @@ class AgGrid extends HTMLElement {
 
     this._events = collection;
 
-    this._api.setGridOption(eventName, function (args) {
+    this.api.setGridOption(eventName, function (args) {
       Object.values(collection).map((event) => event(args));
     });
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mercurymedia/elm-ag-grid",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "",
   "main": "ag-grid-webcomponent/index.js",
   "files": [


### PR DESCRIPTION
The `4.0.0` update unfortunately broke the AgGrid API we expose from the custom element.

This patch upgrade readds that attribute.