### PR TITLE
Fix setting empty row data

### DIFF
--- a/ELM_CHANGELOG.md
+++ b/ELM_CHANGELOG.md
@@ -1,5 +1,9 @@
 # Elm Changelog
 
+## [28.0.1]
+
+- Fix: Update table with empty row data
+
 ## [28.0.0]
 
 - Add `Column` custom type to differentiate between columns and column groups

--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "mercurymedia/elm-ag-grid",
     "summary": "AgGrid integration for Elm",
     "license": "MIT",
-    "version": "28.0.0",
+    "version": "28.0.1",
     "exposed-modules": [
         "AgGrid.ContextMenu",
         "AgGrid.Expression",

--- a/src/AgGrid.elm
+++ b/src/AgGrid.elm
@@ -1895,13 +1895,9 @@ encodeRenderer data column =
 
 encodeData : GridConfig dataType -> List (Column dataType) -> List dataType -> String
 encodeData gridConfig columns data =
-    if List.isEmpty data then
-        Json.Encode.null |> Json.Encode.encode 0
-
-    else
-        data
-            |> Json.Encode.list (encodeRow gridConfig columns)
-            |> Json.Encode.encode 0
+    data
+        |> Json.Encode.list (encodeRow gridConfig columns)
+        |> Json.Encode.encode 0
 
 
 cellUpdateDecoder : Decoder Decode.Value


### PR DESCRIPTION
Setting a rowData of `null` does not work and will not update the table data. Instead we need to set an actual empty list.

This behavior might be broken since we updated the AgGrid packages to 31.1.1