### PR TITLE
Expose fieldName, oldValue and newValue on onCellEditRequest

### DIFF
--- a/NPM_CHANGELOG.md
+++ b/NPM_CHANGELOG.md
@@ -1,5 +1,12 @@
 # NPM Changelog
 
+## [4.1.1]
+
+- Add the following properties to the `editRequest` event:
+  - `field` the name of the actual changed field
+  - `newValue` the new value of the field
+  - `oldValue` the old value of the field
+
 ## [4.1.0]
 
 - Add support for column groups

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The latest [Elm package version](https://package.elm-lang.org/packages/mercuryme
 | 19.0.0 - 22.0.0 |       3.5.0        |
 | 23.0.0 - 23.1.0 |       3.6.0        |
 | 24.0.0 - 27.0.2 |   3.7.0 - 4.0.2    |
-| 28.0.0 - *      |   3.7.0 - 4.1.0    |
+| 28.0.0 - *      |   3.7.0 - 4.1.1    |
 
 ## Ag Grid Enterprise
 

--- a/ag-grid-webcomponent/index.js
+++ b/ag-grid-webcomponent/index.js
@@ -306,7 +306,10 @@ class AgGrid extends HTMLElement {
         newData[e.column.colId] = e.newValue;
         const editEvent = new CustomEvent("editRequest", {
           detail: {
-            data: newData
+            data: newData,
+            oldValue: e.oldValue,
+            newValue: e.newValue,
+            field: e.colDef.field
           }
         });
         self.dispatchEvent(editEvent);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mercurymedia/elm-ag-grid",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "",
   "main": "ag-grid-webcomponent/index.js",
   "files": [


### PR DESCRIPTION
### Description

Added the following fields to onCellEditRequest:

- `field`
- `oldValue`
- `newValue`

This makes it possible to just decode the value for the field that actually changed.

REF: https://www.ag-grid.com/javascript-data-grid/cell-editing/#reference-editing-cellEditRequest
