### PR TITLE
Fix filter condition encoding

### DIFF
--- a/ELM_CHANGELOG.md
+++ b/ELM_CHANGELOG.md
@@ -1,5 +1,9 @@
 # Elm Changelog
 
+## [32.0.1]
+
+- Updated the `filterState` model structure. Previously, it used `{condition1: Condition, condition2: Condition}`; now it adopts a more flexible `{conditions: List Condition}` structure.
+
 ## [32.0.0]
 
 - Updated `ag-grid-community` packages.

--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "mercurymedia/elm-ag-grid",
     "summary": "AgGrid integration for Elm",
     "license": "MIT",
-    "version": "32.0.0",
+    "version": "32.0.1",
     "exposed-modules": [
         "AgGrid.ContextMenu",
         "AgGrid.Expression",

--- a/src/AgGrid.elm
+++ b/src/AgGrid.elm
@@ -495,8 +495,7 @@ type alias TextFilterAttrs =
     { filter : Maybe String
     , type_ : Maybe String
     , operator : Maybe String
-    , condition1 : Maybe TextFilterCondition
-    , condition2 : Maybe TextFilterCondition
+    , conditions : List TextFilterCondition
     }
 
 
@@ -510,8 +509,7 @@ type alias NumberFilterAttrs =
     { filter : Maybe Float
     , type_ : Maybe String
     , operator : Maybe String
-    , condition1 : Maybe NumberFilterCondition
-    , condition2 : Maybe NumberFilterCondition
+    , conditions : List NumberFilterCondition
     }
 
 
@@ -526,8 +524,7 @@ type alias DateFilterAttrs =
     , dateTo : Maybe String
     , type_ : Maybe String
     , operator : Maybe String
-    , condition1 : Maybe DateFilterCondition
-    , condition2 : Maybe DateFilterCondition
+    , conditions : List DateFilterCondition
     }
 
 
@@ -1488,8 +1485,7 @@ textFilterDecoder =
         |> DecodePipeline.optional "filter" (Decode.nullable Decode.string) Nothing
         |> DecodePipeline.optional "type" (Decode.nullable Decode.string) Nothing
         |> DecodePipeline.optional "operator" (Decode.nullable Decode.string) Nothing
-        |> DecodePipeline.optional "condition1" (Decode.nullable textFilterConditionDecoder) Nothing
-        |> DecodePipeline.optional "condition2" (Decode.nullable textFilterConditionDecoder) Nothing
+        |> DecodePipeline.optional "conditions" (Decode.list textFilterConditionDecoder) []
 
 
 textFilterConditionDecoder : Decoder TextFilterCondition
@@ -1505,8 +1501,7 @@ numberFilterDecoder =
         |> DecodePipeline.optional "filter" (Decode.nullable Decode.float) Nothing
         |> DecodePipeline.optional "type" (Decode.nullable Decode.string) Nothing
         |> DecodePipeline.optional "operator" (Decode.nullable Decode.string) Nothing
-        |> DecodePipeline.optional "condition1" (Decode.nullable numberFilterConditionDecoder) Nothing
-        |> DecodePipeline.optional "condition2" (Decode.nullable numberFilterConditionDecoder) Nothing
+        |> DecodePipeline.optional "conditions" (Decode.list numberFilterConditionDecoder) []
 
 
 numberFilterConditionDecoder : Decoder NumberFilterCondition
@@ -1523,8 +1518,7 @@ dateFilterDecoder =
         |> DecodePipeline.optional "dateTo" (Decode.nullable Decode.string) Nothing
         |> DecodePipeline.optional "type" (Decode.nullable Decode.string) Nothing
         |> DecodePipeline.optional "operator" (Decode.nullable Decode.string) Nothing
-        |> DecodePipeline.optional "condition1" (Decode.nullable dateFilterConditionDecoder) Nothing
-        |> DecodePipeline.optional "condition2" (Decode.nullable dateFilterConditionDecoder) Nothing
+        |> DecodePipeline.optional "conditions" (Decode.list dateFilterConditionDecoder) []
 
 
 dateFilterConditionDecoder : Decoder DateFilterCondition
@@ -1599,8 +1593,7 @@ filterStateEncoder filterState =
                 , ( "dateTo", encodeMaybe Json.Encode.string attrs.dateTo )
                 , ( "type", encodeMaybe Json.Encode.string attrs.type_ )
                 , ( "operator", encodeMaybe Json.Encode.string attrs.operator )
-                , ( "condition1", encodeMaybe dateFilterConditionEncoder attrs.condition1 )
-                , ( "condition2", encodeMaybe dateFilterConditionEncoder attrs.condition2 )
+                , ( "conditions", Json.Encode.list dateFilterConditionEncoder attrs.conditions )
                 ]
 
         NumberFilterState attrs ->
@@ -1609,8 +1602,7 @@ filterStateEncoder filterState =
                 , ( "filter", encodeMaybe Json.Encode.float attrs.filter )
                 , ( "type", encodeMaybe Json.Encode.string attrs.type_ )
                 , ( "operator", encodeMaybe Json.Encode.string attrs.operator )
-                , ( "condition1", encodeMaybe numberFilterConditionEncoder attrs.condition1 )
-                , ( "condition2", encodeMaybe numberFilterConditionEncoder attrs.condition2 )
+                , ( "conditions", Json.Encode.list numberFilterConditionEncoder attrs.conditions )
                 ]
 
         SetFilterState attrs ->
@@ -1625,8 +1617,7 @@ filterStateEncoder filterState =
                 , ( "filter", encodeMaybe Json.Encode.string attrs.filter )
                 , ( "type", encodeMaybe Json.Encode.string attrs.type_ )
                 , ( "operator", encodeMaybe Json.Encode.string attrs.operator )
-                , ( "condition1", encodeMaybe textFilterConditionEncoder attrs.condition1 )
-                , ( "condition2", encodeMaybe textFilterConditionEncoder attrs.condition2 )
+                , ( "conditions", Json.Encode.list textFilterConditionEncoder attrs.conditions )
                 ]
 
 


### PR DESCRIPTION
This probably changed in one of the version increases. This affected the user when using multiple filters or just storing filter states in general